### PR TITLE
Changes list-equal and map-equal for cases with the same blank node

### DIFF
--- a/spec/editors_draft.html
+++ b/spec/editors_draft.html
@@ -1492,7 +1492,7 @@
               <li>If <var>elmt<sub>2</sub></var> is <a>null</a> and <var>elmt<sub>1</sub></var> is not <a>null</a>, return `false`.</li>
               <li>If neither <var>elmt<sub>1</sub></var> nor <var>elmt<sub>2</sub></var> is <a>null</a>, then:
                 <ol>
-                  <li>If <var>elmt<sub>1</sub></var> is a blank node and <var>elmt<sub>2</sub></var> is a blank node, terminate with an error.</li>
+                  <li>If <var>elmt<sub>1</sub></var> is a blank node, <var>elmt<sub>2</sub></var> is a blank node, and they are not the same blank node, terminate with an error.</li>
                   <li>If evaluating the SPARQL expression <var>elmt<sub>1</sub></var> = <var>elmt<sub>2</sub></var> results in an error, terminate with an error.</li>
                   <li>If evaluating the SPARQL expression <var>elmt<sub>1</sub></var> = <var>elmt<sub>2</sub></var> results in `false`, return `false`.</li>
                 </ol>
@@ -1551,7 +1551,7 @@
               <li>If <var>v<sub>2</sub></var> is <a>null</a> and <var>v<sub>1</sub></var> is not <a>null</a>, return `false`.</li>
               <li>If neither <var>v<sub>1</sub></var> nor <var>v<sub>2</sub></var> is <a>null</a>, then:
                 <ol>
-                  <li>If <var>v<sub>1</sub></var> is a blank node and <var>v<sub>2</sub></var> is a blank node, set |error| to `true` and move on to the next map entry in <var>map<sub>1</sub></var> (i.e., skip over the remaining instructions within this for loop).</li>
+                  <li>If <var>v<sub>1</sub></var> is a blank node, <var>v<sub>2</sub></var> is a blank node, and they are not the same blank node, then set |error| to `true` and move on to the next map entry in <var>map<sub>1</sub></var> (i.e., skip over the remaining instructions within this for loop).</li>
                   <li>If evaluating the SPARQL expression <var>v<sub>2</sub></var> = <var>v<sub>1</sub></var> results in an error, set |error| to `true` and move on to the next map entry in <var>map<sub>1</sub></var> (i.e., skip over the remaining instructions within this for loop).</li>
                   <li>If evaluating the SPARQL expression <var>v<sub>2</sub></var> = <var>v<sub>1</sub></var> results in `false`, return `false`.</li>
                 </ol>

--- a/tests/list-functions/list-equals-07.rq
+++ b/tests/list-functions/list-equals-07.rq
@@ -3,5 +3,5 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
 	BIND( ( "[_:b]"^^cdt:List = "[_:b]"^^cdt:List ) AS ?result )
-	FILTER( ! BOUND(?result) )
+	FILTER( ?result = true )
 }

--- a/tests/list-functions/list-equals-09.rq
+++ b/tests/list-functions/list-equals-09.rq
@@ -4,5 +4,5 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 ASK {
 	BIND( BNODE() AS ?x )
 	BIND( ( cdt:List(?x) = cdt:List(?x) ) AS ?result )
-	FILTER( ! BOUND(?result) )
+	FILTER( ?result = true )
 }

--- a/tests/map-functions/map-equals-06.rq
+++ b/tests/map-functions/map-equals-06.rq
@@ -3,5 +3,5 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
 	BIND( ( "{1:_:b1}"^^cdt:Map = "{1:_:b1}"^^cdt:Map ) AS ?result )
-	FILTER( ! BOUND(?result) )
+	FILTER( ?result = true )
 }

--- a/tests/map-functions/map-equals-09.rq
+++ b/tests/map-functions/map-equals-09.rq
@@ -4,5 +4,5 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 ASK {
 	BIND( BNODE() AS ?x )
 	BIND( ( cdt:Map(1, ?x) = cdt:Map(1, ?x) ) AS ?result )
-	FILTER( ! BOUND(?result) )
+	FILTER( ?result = true )
 }


### PR DESCRIPTION
Related to PR #2, the definitions of `list-equal` and `map-equal` need to be changed as follows. Currently, during the pairwise comparison of elements of the given two lists, whenever at least one of the two elements is a blank node, the overall `=` comparison of the two lists literals results in an error. The required change (as implemented by this PR) is: If both of the elements happen to be the same blank node, then there should be no error. Similarly, for maps.

This PR changes the corresponding steps in the algorithms that define the expected behavior of `list-equal` (Section 5.1) and of `map-equal` (Section 5.2). Additionally, this PR changes the corresponding tests.