### PR TITLE
Test to create a cdt:List with blank nodes via STRDT

### DIFF
--- a/tests/bnodes/bnodes-sparql-10.rq
+++ b/tests/bnodes/bnodes-sparql-10.rq
@@ -1,0 +1,15 @@
+PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
+PREFIX ex:     <http://example.org/>
+
+ASK {
+	BIND( "[_:b, 42]"^^cdt:List AS ?list1 )
+	BIND( "[_:b, 43]" AS ?str )
+	BIND( STRDT(?str, cdt:List) AS ?list2 )
+
+	BIND( cdt:get(?list1,1) AS ?e1 )
+	BIND( cdt:get(?list2,1) AS ?e2 )
+
+	FILTER( isBLANK(?e1) )
+	FILTER( isBLANK(?e2) )
+	FILTER( ?e1 = ?e2 )
+}

--- a/tests/bnodes/manifest.ttl
+++ b/tests/bnodes/manifest.ttl
@@ -66,6 +66,7 @@
 		:bnodes-sparql-07
 		:bnodes-sparql-08
 		:bnodes-sparql-09
+		:bnodes-sparql-10
 
 		:bnodes-sparql-11
 		:bnodes-sparql-12
@@ -564,6 +565,15 @@
     mf:action
          [ qt:data   <empty.ttl> ;
            qt:query  <bnodes-sparql-09.rq> ] ;
+    mf:result  <true.srx> .
+
+:bnodes-sparql-10  rdf:type  mf:QueryEvaluationTest ;
+    mf:name         "bnodes-sparql-10" ;
+    rdfs:comment    "same blank node identifier within two different cdt:List literals, where one of them is constructed using STRDT" ;
+    dawgt:approval  dawgt:Proposed ;
+    mf:action
+         [ qt:data   <empty.ttl> ;
+           qt:query  <bnodes-sparql-10.rq> ] ;
     mf:result  <true.srx> .
 
 :bnodes-sparql-11  rdf:type  mf:QueryEvaluationTest ;


### PR DESCRIPTION
As a follow up on PR #4, this PR adds the controversial `:bnodes-sparql-10` test back into the set of blank node related tests.

I don't mean that we necessarily need to include this test. It is just something that came to my mind and I wanted to bring it up for discussion. In fact, we may also include the inverse of this test.