### PR TITLE
Add orderby tests to top-level manifest.

### DIFF
--- a/tests/manifest-all.ttl
+++ b/tests/manifest-all.ttl
@@ -6,10 +6,11 @@
 <> a mf:Manifest ;
     rdfs:label "SPARQL Composite Datatype tests" ;
     mf:include (
-        <unfold/manifest.ttl>
+        <bnodes/manifest.ttl>
         <fold/manifest.ttl>
         <list-functions/manifest.ttl>
         <map-functions/manifest.ttl>
-        <bnodes/manifest.ttl>
+        <orderby/manifest.ttl>
+        <unfold/manifest.ttl>
     ) ;
 .


### PR DESCRIPTION
Adds missing reference to the orderby tests in the top-level `manifest-all.ttl`, and sorts the manifest entries.