### PR TITLE
Export Requirements

### DIFF
--- a/spec/editors_draft.html
+++ b/spec/editors_draft.html
@@ -1364,9 +1364,10 @@
     <section>
       <h2>Importing Requirements</h2>
       <p>
-        Conforming implementations MUST process <a>cdt:List literals</a> and <a>cdt:Map literals</a> during loading, replacing, in their lexical form, any substring <var>bnl</var>
-        matching the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production of the grammar
-        with a string <var>bnl'</var> such that
+        Conforming implementations MUST process <a>cdt:List literals</a> and <a>cdt:Map literals</a> during loading as follows.
+        In the lexical form of these literals, every substring <var>bnl</var>
+        that would match the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production of the <a href="#list-datatype-lexspace">grammar</a> when parsing the whole lexical form
+        MUST be replaced by a string <var>bnl'</var> such that
       </p>
       
       <ul>
@@ -1381,7 +1382,7 @@
         <li>
           if the format of the document being processed does not have a mechanism for explicitly identifying blank nodes outside of cdt:List and cdt:Map literals, then <var>bnl'</var> must be picked such that <i><a>bnl2bn</a></i>(<var>bnl'</var>) is a fresh blank node not already used in the SPARQL system or RDF Dataset, and
         </li>
-        <li>within the scope of the document being processed, all occurrences of <var>bnl</var> used to represent a blank node identifier within the lexical forms of cdt:List and cdt:Map literals are replaced with the same <var>bnl'</var> value, and</li>
+        <li>within the scope of the document being processed, all occurrences of <var>bnl</var> used to represent a blank node identifier within the lexical forms of cdt:List and cdt:Map literals are replaced with the same <var>bnl'</var> value (this applies recursively also to cdt:List and cdt:Map literals contained as elements within the term list or term map of other such literals), and</li>
         <li>within the scope of the document being processed, no other substring that matches the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production within the lexical form of a cdt:List or cdt:Map literal is replaced by the same substring <var>bnl'</var>.</li>
         </li>
       </ul>
@@ -1508,16 +1509,17 @@
       <h2>Exporting Requirements</h2>
 
       <p>
-        Conforming implementations MUST process <a>cdt:List literals</a> and <a>cdt:Map literals</a> during export, replacing, in their lexical form, any substring <var>bnl</var>
-        matching the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production of the grammar
-        with a string <var>bnl'</var> such that
+        Conforming implementations MUST process <a>cdt:List literals</a> and <a>cdt:Map literals</a> during export as follows.
+        In the lexical form of these literals, every substring <var>bnl</var>
+        that would match the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production of the <a href="#list-datatype-lexspace">grammar</a> when parsing the whole lexical form
+        MUST be replaced by a string <var>bnl'</var> such that
       </p>
 
       <ul>
         <li>
           <var>bnl'</var> also matches the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production; i.e., <var>bnl'</var> is of the form _:<var>b</var> where <var>b</var> is a blank node identifier, and
         </li>
-        <li>within the scope of the document being serialized, all occurrences of <var>bnl</var> used to represent a blank node identifier within the lexical forms of cdt:List and cdt:Map literals are replaced with the same <var>bnl'</var> value, and</li>
+        <li>within the scope of the document being serialized, all occurrences of <var>bnl</var> used to represent a blank node identifier within the lexical forms of cdt:List and cdt:Map literals are replaced with the same <var>bnl'</var> value (this applies recursively also to cdt:List and cdt:Map literals contained as elements within the term list or term map of other such literals), and</li>
         <li>within the scope of the document being serialized, no other substring that matches the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production within the lexical form of a cdt:List or cdt:Map literal is replaced by the same substring <var>bnl'</var>, and</li>
         <li>
           assuming that the format of the document being serialized has a mechanism for explicitly identifying blank nodes outside of cdt:List and cdt:Map literals (e.g., `_:b1` syntax in N-Triples and in Turtle, `rdf:nodeID` in RDF/XML),

--- a/spec/editors_draft.html
+++ b/spec/editors_draft.html
@@ -1518,8 +1518,8 @@
         <li>within the scope of the document being serialized, two distinct <var>id</var> blank node identifiers are replaced with distinct <var>b</var> values, and</li>
         <li>
           assuming that the format of the document being serialized has a mechanism for explicitly identifying blank nodes outside of cdt:List and cdt:Map literals (e.g., `_:b1` syntax in N-Triples and in Turtle, `rdf:nodeID` in RDF/XML),
-          and the blank node <var>B</var> is contained in the data to be serialized both inside and outside of composite value literals,
-          then the serializer for this document format MUST serialize <var>B</var> using the blank node identifier <var>b</var> (both inside and outside of composite values)
+          if the blank node <var>B</var> = <i><a>bnl2bn</a></i>("_:" + <var>id</var>) is contained in the data to be serialized outside of cdt:List and cdt:Map literals,
+          then the serializer for this document format MUST serialize <var>B</var> using the blank node identifier <var>b</var>, both inside and outside of the cdt:List and cdt:Map literals.
           <div class="note">
             Regarding the assumption in the previous point, we are not aware of serialization formats for RDF in which blank nodes cannot be identified explicitly by blank node identifiers. We note, however, if there was such a format, it would have the problem that the identity of a blank node cannot be preserved in such a serialization if the blank note is used both within a cdt:List or a cdt:Map literal and outside of such literals (i.e., directly in the RDF data that contains these literals).
           </div>

--- a/spec/editors_draft.html
+++ b/spec/editors_draft.html
@@ -1506,10 +1506,7 @@
 
     <section>
       <h2>Exporting Requirements</h2>
-      <p>
-        TODO
-      </p>
-<!--
+
       <p>
         Conforming implementations MUST process <a>cdt:List literals</a> and <a>cdt:Map literals</a> during export, replacing, in their lexical form, any substring _:<var>id</var>
         matching the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production of the grammar
@@ -1549,22 +1546,18 @@
          data-transform="updateExample"
          data-content-type="text/n-triples"
          class="nohighlight example">
--->
       <!--
       _:b004 <http://example.org/p3> "[ _:b004 ]"^^<http://w3id.org/awslabs/neptune/SPARQL-CDTs/List> .
       -->
-<!--
       </pre>
       <pre id="export-consistent-ids-turtle-result"
          title="Exporting consistent blank node identifiers for blank nodes shared between a cdt:List literal and the RDF data that contains this literal: Result"
          data-transform="updateExample"
          data-content-type="text/turtle"
          class="nohighlight example">
--->
       <!--
       _:xyz ex:p3 "[ _:xyz ]"^^cdt:List .
       -->
-<!--
       </pre>
 
       <p>
@@ -1575,21 +1568,18 @@
          data-transform="updateExample"
          data-content-type="application/sparql-query"
          class="nohighlight example">
--->
       <!--
       SELECT ?b ?list WHERE {
         BIND(BNODE() AS ?b)
         BIND(cdt:List(?b) AS ?list)
       }
       -->
-<!--
       </pre>
       <pre id="export-consistent-ids-srj-result"
          title="Exporting consistent blank node identifiers in SPARQL query results: Result"
          data-transform="updateExample"
          data-content-type="application/sparql-results+json"
          class="nohighlight example">
--->
       <!--
 {
   "head": {
@@ -1609,9 +1599,7 @@
   }
 }
       -->
-<!--
       </pre>
--->
     </section>
       
   </section>

--- a/spec/editors_draft.html
+++ b/spec/editors_draft.html
@@ -1508,17 +1508,20 @@
       <h2>Exporting Requirements</h2>
 
       <p>
-        Conforming implementations MUST process <a>cdt:List literals</a> and <a>cdt:Map literals</a> during export, replacing, in their lexical form, any substring _:<var>id</var>
+        Conforming implementations MUST process <a>cdt:List literals</a> and <a>cdt:Map literals</a> during export, replacing, in their lexical form, any substring <var>bnl</var>
         matching the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production of the grammar
-        with a string "_:"+<var>b</var> where <var>b</var> is a blank node identifier, such that
+        with a string <var>bnl'</var> such that
       </p>
 
       <ul>
-        <li>within the scope of the document being serialized, all occurrences of <var>id</var> used as a blank node identifier (both inside and outside of composite values) are replaced with the same <var>b</var> value, and</li>
-        <li>within the scope of the document being serialized, two distinct <var>id</var> blank node identifiers are replaced with distinct <var>b</var> values, and</li>
+        <li>
+          <var>bnl'</var> also matches the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production; i.e., <var>bnl'</var> is of the form _:<var>b</var> where <var>b</var> is a blank node identifier, and
+        </li>
+        <li>within the scope of the document being serialized, all occurrences of <var>bnl</var> used to represent a blank node identifier within the lexical forms of cdt:List and cdt:Map literals are replaced with the same <var>bnl'</var> value, and</li>
+        <li>within the scope of the document being serialized, no other substring that matches the <a data-cite="TURTLE#grammar-production-BLANK_NODE_LABEL">`BLANK_NODE_LABEL`</a> production within the lexical form of a cdt:List or cdt:Map literal is replaced by the same substring <var>bnl'</var>, and</li>
         <li>
           assuming that the format of the document being serialized has a mechanism for explicitly identifying blank nodes outside of cdt:List and cdt:Map literals (e.g., `_:b1` syntax in N-Triples and in Turtle, `rdf:nodeID` in RDF/XML),
-          if the blank node <var>B</var> = <i><a>bnl2bn</a></i>("_:" + <var>id</var>) is contained in the data to be serialized outside of cdt:List and cdt:Map literals,
+          if the blank node <var>B</var> = <i><a>bnl2bn</a></i>(<var>bnl</var>) is contained in the data to be serialized outside of cdt:List and cdt:Map literals,
           then the serializer for this document format MUST serialize <var>B</var> using the blank node identifier <var>b</var>, both inside and outside of the cdt:List and cdt:Map literals.
           <div class="note">
             Regarding the assumption in the previous point, we are not aware of serialization formats for RDF in which blank nodes cannot be identified explicitly by blank node identifiers. We note, however, if there was such a format, it would have the problem that the identity of a blank node cannot be preserved in such a serialization if the blank note is used both within a cdt:List or a cdt:Map literal and outside of such literals (i.e., directly in the RDF data that contains these literals).


### PR DESCRIPTION
This PR adds the export requirements that we started working on in PR #2 

The initial version of this PR is simply a copy of the text that we already had in PR #2. Primarily, there are still the following two points that still need to be resolved.

1. While I generally agree with the new third bullet point in the given list of requirements, this point feels somewhat detached from the context in which these bullet points are listed. I mean, the context is that there is some substring "`_:`_id_" in the lexical form of some cdt:List or cdt:Map literal to be exported, but this bullet point does not talk at all about this substring / about _id_.
2. Related to the previous point, that third bullet point seems to assume systems that represent CDT literals internally based on their value form (how would such a system otherwise know that it is the same blank node B that is both inside and outside of CDT literals?). So, the issue that I see here is that it is not clear how the requirement of this bullet point can apply to systems that represent CDT literals internally based on their lexical form.
