### PR TITLE
Add tests for BNODE export requirements

### DIFF
--- a/tests/bnodes/bnodes-export-rdf-01-construct.rq
+++ b/tests/bnodes/bnodes-export-rdf-01-construct.rq
@@ -1,0 +1,10 @@
+PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
+PREFIX ex:     <http://example.org/>
+
+CONSTRUCT {
+	?b ex:list ?list
+}
+WHERE {
+	BIND(BNODE() AS ?b)
+	BIND(cdt:List(?b) AS ?list)
+}

--- a/tests/bnodes/bnodes-export-rdf-01.rq
+++ b/tests/bnodes/bnodes-export-rdf-01.rq
@@ -1,0 +1,8 @@
+PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
+PREFIX ex:     <http://example.org/>
+
+ASK {
+	?b ex:list ?list .
+	BIND(cdt:get(?list, 1) AS ?e)
+	FILTER(SAMETERM(?b, ?e))
+}

--- a/tests/bnodes/bnodes-export-service-01.rq
+++ b/tests/bnodes/bnodes-export-service-01.rq
@@ -1,0 +1,11 @@
+PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
+PREFIX ex:     <http://example.org/>
+
+ASK {
+	SERVICE <http://example.org/sparql> {
+		BIND(BNODE() AS ?b)
+		BIND(cdt:List(?b) AS ?list)
+	}
+	BIND(cdt:get(?list, 1) AS ?e)
+	FILTER(SAMETERM(?b, ?e))
+}

--- a/tests/bnodes/manifest.ttl
+++ b/tests/bnodes/manifest.ttl
@@ -89,6 +89,11 @@
 		:bnodes-turtle-sparql-02
 		:bnodes-turtle-sparql-03
 		:bnodes-turtle-sparql-04
+		
+		:bnodes-export-turtle-01
+		:bnodes-export-ntriples-01
+		:bnodes-export-rdfxml-01
+		:bnodes-export-service-01
     ) .
 
 :bnodes-turtle-01  rdf:type  mf:QueryEvaluationTest ;
@@ -746,4 +751,53 @@
     mf:action
          [ qt:data   <bnodes-turtle-sparql-04.ttl> ;
            qt:query  <bnodes-turtle-sparql-04.rq> ] ;
+    mf:result  <true.srx> .
+
+
+:bnodes-export-service-01  rdf:type  mf:QueryEvaluationTest ;
+    mf:name         "bnodes-export-service-01" ;
+    rdfs:comment    "bnodes appearing both inside and outside of a CDT literal in SPARQL results need to be serialized with the same identifier so they reference the same value" ;
+    dawgt:approval  dawgt:Proposed ;
+    mf:action [
+           qt:serviceData [
+                   qt:endpoint <http://example.org/sparql> ;
+                   qt:data     <empty.ttl>
+           ] ;
+           qt:query  <bnodes-export-service-01.rq> ] ;
+    mf:result  <true.srx> .
+
+:bnodes-export-turtle-01  rdf:type  mf:QueryEvaluationTest ;
+    mf:name         "bnodes-export-turtle-01" ;
+    rdfs:comment    "bnodes appearing both inside and outside of a CDT literal in SPARQL results need to be serialized with the same identifier so they reference the same value" ;
+    dawgt:approval  dawgt:Proposed ;
+    mf:action
+         [ qt:constructedData [
+             qt:query  <bnodes-export-rdf-01-construct.rq> ;
+             qt:format "text/turtle"
+           ] ;
+           qt:query  <bnodes-export-rdf-01.rq> ] ;
+    mf:result  <true.srx> .
+
+:bnodes-export-ntriples-01  rdf:type  mf:QueryEvaluationTest ;
+    mf:name         "bnodes-export-ntriples-01" ;
+    rdfs:comment    "bnodes appearing both inside and outside of a CDT literal in SPARQL results need to be serialized with the same identifier so they reference the same value" ;
+    dawgt:approval  dawgt:Proposed ;
+    mf:action
+         [ qt:constructedData [
+             qt:query  <bnodes-export-rdf-01-construct.rq> ;
+             qt:format "application/n-triples"
+           ] ;
+           qt:query  <bnodes-export-rdf-01.rq> ] ;
+    mf:result  <true.srx> .
+
+:bnodes-export-rdfxml-01  rdf:type  mf:QueryEvaluationTest ;
+    mf:name         "bnodes-export-rdfxml-01" ;
+    rdfs:comment    "bnodes appearing both inside and outside of a CDT literal in SPARQL results need to be serialized with the same identifier so they reference the same value" ;
+    dawgt:approval  dawgt:Proposed ;
+    mf:action
+         [ qt:constructedData [
+             qt:query  <bnodes-export-rdf-01-construct.rq> ;
+             qt:format "application/rdf+xml"
+           ] ;
+           qt:query  <bnodes-export-rdf-01.rq> ] ;
     mf:result  <true.srx> .

--- a/tests/bnodes/manifest.ttl
+++ b/tests/bnodes/manifest.ttl
@@ -771,7 +771,7 @@
     rdfs:comment    "bnodes appearing both inside and outside of a CDT literal in SPARQL results need to be serialized with the same identifier so they reference the same value" ;
     dawgt:approval  dawgt:Proposed ;
     mf:action
-         [ qt:constructedData [
+         [ qt:constructDataFile [
              qt:query  <bnodes-export-rdf-01-construct.rq> ;
              qt:format "text/turtle"
            ] ;
@@ -783,7 +783,7 @@
     rdfs:comment    "bnodes appearing both inside and outside of a CDT literal in SPARQL results need to be serialized with the same identifier so they reference the same value" ;
     dawgt:approval  dawgt:Proposed ;
     mf:action
-         [ qt:constructedData [
+         [ qt:constructDataFile [
              qt:query  <bnodes-export-rdf-01-construct.rq> ;
              qt:format "application/n-triples"
            ] ;
@@ -795,7 +795,7 @@
     rdfs:comment    "bnodes appearing both inside and outside of a CDT literal in SPARQL results need to be serialized with the same identifier so they reference the same value" ;
     dawgt:approval  dawgt:Proposed ;
     mf:action
-         [ qt:constructedData [
+         [ qt:constructDataFile [
              qt:query  <bnodes-export-rdf-01-construct.rq> ;
              qt:format "application/rdf+xml"
            ] ;


### PR DESCRIPTION
Four new tests are added:

```
:bnodes-export-service-01
:bnodes-export-turtle-01
:bnodes-export-ntriples-01
:bnodes-export-rdfxml-01
```

The first is a test for rewriting CDTs with bnodes when they are in the SPARQL results format received during the evaluation of a SERVICE pattern.

The following three tests are for variations of loading CDTs from RDF files of different formats, based on a proposed extension to the DAWG manifest vocabulary, allowing the RDF input to a test to be generated by a separate CONSTRUCT query, specified using the new terms `qt:constructedData`, and `qt:format`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
