### PR TITLE
Fixing list-functions, map-functions, and orderby false positive tests

### DIFF
--- a/tests/list-functions/list-equals-07.rq
+++ b/tests/list-functions/list-equals-07.rq
@@ -2,6 +2,6 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "[_:b]"^^cdt:List = "[_:b]"^^cdt:List ) AS ?result )
+	BIND( ( "[   _:b   ]"^^cdt:List = "[_:b]"^^cdt:List ) AS ?result )
 	FILTER( ?result = true )
 }

--- a/tests/list-functions/list-equals-null-01.rq
+++ b/tests/list-functions/list-equals-null-01.rq
@@ -2,6 +2,6 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND("[1,null,2]"^^cdt:List = "[1,null,2]"^^cdt:List AS ?result)
+	BIND("[ 1 , null , 2 ]"^^cdt:List = "[1,null,2]"^^cdt:List AS ?result)
 	FILTER( ?result = true )
 }

--- a/tests/list-functions/list-equals-null-02.rq
+++ b/tests/list-functions/list-equals-null-02.rq
@@ -2,6 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND("[1,null,2]"^^cdt:List = "[1,44,2]"^^cdt:List AS ?result)
+	BIND(cdt:List(1, ?undef, 2) AS ?list)
+	BIND(?list = "[1,44,2]"^^cdt:List AS ?result)
 	FILTER( ?result = false )
 }

--- a/tests/list-functions/list-greater-equal-null-03.rq
+++ b/tests/list-functions/list-greater-equal-null-03.rq
@@ -2,6 +2,6 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "[null]"^^cdt:List >= "[null]"^^cdt:List ) AS ?result )
+	BIND( ( "[  null  ]"^^cdt:List >= "[null]"^^cdt:List ) AS ?result )
 	FILTER( ?result = true )
 }

--- a/tests/list-functions/list-greater-than-null-03.rq
+++ b/tests/list-functions/list-greater-than-null-03.rq
@@ -2,7 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "[null]"^^cdt:List > "[null]"^^cdt:List ) AS ?result )
+	BIND( ( "[null]"^^cdt:List > "[   null   ]"^^cdt:List ) AS ?result )
 
 	FILTER( BOUND(?result) )
 	FILTER( ?result = false )

--- a/tests/list-functions/list-less-equal-null-03.rq
+++ b/tests/list-functions/list-less-equal-null-03.rq
@@ -2,7 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "[null]"^^cdt:List <= "[null]"^^cdt:List ) AS ?result )
+	BIND( ( "[null]"^^cdt:List <= "[  null  ]"^^cdt:List ) AS ?result )
 
 	FILTER( BOUND(?result) )
 	FILTER( ?result = true )

--- a/tests/list-functions/list-less-than-null-03.rq
+++ b/tests/list-functions/list-less-than-null-03.rq
@@ -2,7 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "[null]"^^cdt:List < "[null]"^^cdt:List ) AS ?result )
+	BIND( ( "[  null  ]"^^cdt:List < "[null]"^^cdt:List ) AS ?result )
 
 	FILTER( BOUND(?result) )
 	FILTER( ?result = false )

--- a/tests/list-functions/sameterm-01.rq
+++ b/tests/list-functions/sameterm-01.rq
@@ -2,5 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(SAMETERM("[]"^^cdt:List, "[]"^^cdt:List))
+	BIND(cdt:List() AS ?list1)
+	BIND(cdt:List() AS ?list2)
+	FILTER(SAMETERM(?list1, ?list2))
 }

--- a/tests/list-functions/sameterm-02.rq
+++ b/tests/list-functions/sameterm-02.rq
@@ -2,5 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(SAMETERM("[1]"^^cdt:List, "[1]"^^cdt:List))
+	BIND(cdt:List(1) AS ?list1)
+	BIND(cdt:List(1) AS ?list2)
+	FILTER(SAMETERM(?list1, ?list2))
 }

--- a/tests/list-functions/sameterm-03.rq
+++ b/tests/list-functions/sameterm-03.rq
@@ -2,5 +2,6 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(!SAMETERM("[1,2]"^^cdt:List, "[1,'2'^^<http://www.w3.org/2001/XMLSchema#integer>]"^^cdt:List))
+	BIND(cdt:List(1,2) AS ?list)
+	FILTER(!SAMETERM(?list, "[1,'2'^^<http://www.w3.org/2001/XMLSchema#integer>]"^^cdt:List))
 }

--- a/tests/list-functions/sameterm-04.rq
+++ b/tests/list-functions/sameterm-04.rq
@@ -2,5 +2,6 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(!SAMETERM("[1,2,3]"^^cdt:List, "[  1, 2, 3  ]"^^cdt:List))
+	BIND(cdt:List(1,2,3) AS ?list)
+	FILTER(!SAMETERM(?list, "[  1 ,  2  ,   3   ]"^^cdt:List))
 }

--- a/tests/list-functions/sameterm-null-01.rq
+++ b/tests/list-functions/sameterm-null-01.rq
@@ -2,5 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(SAMETERM("[1,null,2]"^^cdt:List, "[1,null,2]"^^cdt:List))
+	BIND(cdt:List(1, ?undef1, 2) AS ?list1)
+	BIND(cdt:List(1, ?undef2, 2) AS ?list2)
+	FILTER(SAMETERM(?list1, ?list2))
 }

--- a/tests/map-functions/map-equals-04.rq
+++ b/tests/map-functions/map-equals-04.rq
@@ -2,6 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND("{1:2}"^^cdt:Map = "{'+1'^^<http://www.w3.org/2001/XMLSchema#integer> : 2.0}"^^cdt:Map AS ?result)
+        BIND( cdt:Map(1,2) AS ?map)
+	BIND( ?map = "{'+1'^^<http://www.w3.org/2001/XMLSchema#integer> : 2.0}"^^cdt:Map AS ?result)
 	FILTER( ! ?result )
 }

--- a/tests/map-functions/map-equals-06.rq
+++ b/tests/map-functions/map-equals-06.rq
@@ -2,6 +2,6 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "{1:_:b1}"^^cdt:Map = "{1:_:b1}"^^cdt:Map ) AS ?result )
+	BIND( ( "{  1  : _:b1   }"^^cdt:Map = "{1:_:b1}"^^cdt:Map ) AS ?result )
 	FILTER( ?result = true )
 }

--- a/tests/map-functions/map-equals-null-01.rq
+++ b/tests/map-functions/map-equals-null-01.rq
@@ -2,7 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND("{1:null}"^^cdt:Map = "{1:null}"^^cdt:Map AS ?result)
+	BIND("{   1   :   null   }"^^cdt:Map = "{1:null}"^^cdt:Map AS ?result)
 
 	FILTER( BOUND(?result) )
 	FILTER( ?result = true )

--- a/tests/map-functions/map-equals-null-02.rq
+++ b/tests/map-functions/map-equals-null-02.rq
@@ -2,7 +2,8 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND("{1:null}"^^cdt:Map = "{1:44}"^^cdt:Map AS ?result)
+        BIND( cdt:Map(1, 44) AS ?map )
+	BIND("{1:null}"^^cdt:Map = ?map AS ?result)
 
 	FILTER( BOUND(?result) )
 	FILTER( ?result = false )

--- a/tests/map-functions/map-greater-equal-error-01.rq
+++ b/tests/map-functions/map-greater-equal-error-01.rq
@@ -3,8 +3,8 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 # IRIs as map values cannot be compared based on <
 ASK {
-	BIND( "{1: <http://example.org/b>}"^^cdt:Map AS ?map1 )
-	BIND( "{1: <http://example.org/a>}"^^cdt:Map AS ?map2 )
+	BIND( cdt:Map( 1, <http://example.org/b> ) AS ?map1 )
+	BIND( cdt:Map( 1, <http://example.org/a> ) AS ?map2 )
 	BIND( (?map1 >= ?map2 ) AS ?result )
 	FILTER( ! BOUND(?result) )
 }

--- a/tests/map-functions/map-greater-equal-error-02.rq
+++ b/tests/map-functions/map-greater-equal-error-02.rq
@@ -3,8 +3,8 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 # IRIs as map values cannot be compared to literals
 ASK {
-	BIND( "{1: <http://example.org/b>}"^^cdt:Map AS ?map1 )
-	BIND( "{1: 42}"^^cdt:Map AS ?map2 )
+	BIND( cdt:Map( 1, <http://example.org/b> ) AS ?map1 )
+	BIND( cdt:Map( 1, 42 ) AS ?map2 )
 	BIND( (?map1 >= ?map2 ) AS ?result )
 	FILTER( ! BOUND(?result) )
 }

--- a/tests/map-functions/map-greater-equal-null-01.rq
+++ b/tests/map-functions/map-greater-equal-null-01.rq
@@ -2,6 +2,8 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "{1:null}"^^cdt:Map >= "{1:42}"^^cdt:Map ) AS ?result )
+	BIND( cdt:Map( 1, ?undef ) AS ?map1 )
+	BIND( cdt:Map( 1, 42 ) AS ?map2 )
+	BIND( ( ?map1 >= ?map2 ) AS ?result )
 	FILTER( ! BOUND(?result) )
 }

--- a/tests/map-functions/map-greater-equal-null-03.rq
+++ b/tests/map-functions/map-greater-equal-null-03.rq
@@ -2,7 +2,10 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "{1:null}"^^cdt:Map >= "{1:null}"^^cdt:Map ) AS ?result )
+	BIND( cdt:Map(1, ?undef1) AS ?map1 )
+	BIND( cdt:Map(1, ?undef2) AS ?map2 )
+
+	BIND( ( ?map1 >= ?map2 ) AS ?result )
 
 	FILTER( BOUND(?result) )
 	FILTER( ?result = true )

--- a/tests/map-functions/map-greater-than-error-01.rq
+++ b/tests/map-functions/map-greater-than-error-01.rq
@@ -3,8 +3,8 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 # IRIs as map values cannot be compared based on <
 ASK {
-	BIND( "{1: <http://example.org/b>}"^^cdt:Map AS ?map1 )
-	BIND( "{1: <http://example.org/a>}"^^cdt:Map AS ?map2 )
-	BIND( (?map1 > ?map2 ) AS ?result )
+	BIND( cdt:Map(1, <http://example.org/b>) AS ?map1 )
+	BIND( "{1, <http://example.org/a>}"^^cdt:Map AS ?map2 )
+	BIND( (?map1 > ?map2) AS ?result )
 	FILTER( ! BOUND(?result) )
 }

--- a/tests/map-functions/map-greater-than-error-02.rq
+++ b/tests/map-functions/map-greater-than-error-02.rq
@@ -3,7 +3,7 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 # IRIs as map values cannot be compared to literals
 ASK {
-	BIND( "{1: <http://example.org/b>}"^^cdt:Map AS ?map1 )
+	BIND( cdt:Map(1, <http://example.org/b>) AS ?map1 )
 	BIND( "{1: 42}"^^cdt:Map AS ?map2 )
 	BIND( (?map1 > ?map2 ) AS ?result )
 	FILTER( ! BOUND(?result) )

--- a/tests/map-functions/map-greater-than-null-01.rq
+++ b/tests/map-functions/map-greater-than-null-01.rq
@@ -2,6 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "{1:null}"^^cdt:Map > "{1:42}"^^cdt:Map ) AS ?result )
+	BIND( cdt:Map(1, ?undef) AS ?map1 )
+	BIND( ( ?map1 > "{1:42}"^^cdt:Map ) AS ?result )
 	FILTER( ! BOUND(?result) )
 }

--- a/tests/map-functions/map-greater-than-null-03.rq
+++ b/tests/map-functions/map-greater-than-null-03.rq
@@ -2,7 +2,8 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "{1:null}"^^cdt:Map > "{1:null}"^^cdt:Map ) AS ?result )
+	BIND( cdt:Map(1, ?undef) AS ?map1 )
+	BIND( ( ?map1 > "{1:null}"^^cdt:Map ) AS ?result )
 
 	FILTER( BOUND(?result) )
 	FILTER( ?result = false )

--- a/tests/map-functions/map-less-equal-error-01.rq
+++ b/tests/map-functions/map-less-equal-error-01.rq
@@ -3,7 +3,7 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 # IRIs as map values cannot be compared based on <
 ASK {
-	BIND( "{1: <http://example.org/b>}"^^cdt:Map AS ?map1 )
+	BIND( cdt:Map(1, <http://example.org/b>) AS ?map1 )
 	BIND( "{1: <http://example.org/a>}"^^cdt:Map AS ?map2 )
 	BIND( (?map1 <= ?map2 ) AS ?result )
 	FILTER( ! BOUND(?result) )

--- a/tests/map-functions/map-less-equal-error-02.rq
+++ b/tests/map-functions/map-less-equal-error-02.rq
@@ -3,7 +3,7 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 # IRIs as map values cannot be compared to literals
 ASK {
-	BIND( "{1: <http://example.org/b>}"^^cdt:Map AS ?map1 )
+	BIND( cdt:Map(1, <http://example.org/b>) AS ?map1 )
 	BIND( "{1: 42}"^^cdt:Map AS ?map2 )
 	BIND( (?map1 <= ?map2 ) AS ?result )
 	FILTER( ! BOUND(?result) )

--- a/tests/map-functions/map-less-equal-null-01.rq
+++ b/tests/map-functions/map-less-equal-null-01.rq
@@ -2,6 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "{1:null}"^^cdt:Map <= "{1:42}"^^cdt:Map ) AS ?result )
+	BIND( cdt:Map(1, ?undef) AS ?map1 )
+	BIND( ( ?map1 <= "{1:42}"^^cdt:Map ) AS ?result )
 	FILTER( ! BOUND(?result) )
 }

--- a/tests/map-functions/map-less-equal-null-03.rq
+++ b/tests/map-functions/map-less-equal-null-03.rq
@@ -2,7 +2,8 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "{1:null}"^^cdt:Map < "{1:null}"^^cdt:Map ) AS ?result )
+	BIND( cdt:Map(1, ?undef) AS ?map1 )
+	BIND( ( ?map1 < "{1:null}"^^cdt:Map ) AS ?result )
 
 	FILTER( BOUND(?result) )
 	FILTER( ?result = false )

--- a/tests/map-functions/map-less-than-error-01.rq
+++ b/tests/map-functions/map-less-than-error-01.rq
@@ -3,7 +3,7 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 # IRIs as map values cannot be compared based on <
 ASK {
-	BIND( "{1: <http://example.org/b>}"^^cdt:Map AS ?map1 )
+	BIND( cdt:Map(1, <http://example.org/b>) AS ?map1 )
 	BIND( "{1: <http://example.org/a>}"^^cdt:Map AS ?map2 )
 	BIND( (?map1 < ?map2 ) AS ?result )
 	FILTER( ! BOUND(?result) )

--- a/tests/map-functions/map-less-than-error-02.rq
+++ b/tests/map-functions/map-less-than-error-02.rq
@@ -3,7 +3,7 @@ PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 # IRIs as map values cannot be compared to literals
 ASK {
-	BIND( "{1: <http://example.org/b>}"^^cdt:Map AS ?map1 )
+	BIND( cdt:Map(1, <http://example.org/b>) AS ?map1 )
 	BIND( "{1: 42}"^^cdt:Map AS ?map2 )
 	BIND( (?map1 < ?map2 ) AS ?result )
 	FILTER( ! BOUND(?result) )

--- a/tests/map-functions/map-less-than-null-01.rq
+++ b/tests/map-functions/map-less-than-null-01.rq
@@ -2,6 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "{1:null}"^^cdt:Map < "{1:42}"^^cdt:Map ) AS ?result )
+	BIND( cdt:Map(1, ?undef) AS ?map1 )
+	BIND( ( ?map1 < "{1:42}"^^cdt:Map ) AS ?result )
 	FILTER( ! BOUND(?result) )
 }

--- a/tests/map-functions/map-less-than-null-03.rq
+++ b/tests/map-functions/map-less-than-null-03.rq
@@ -2,7 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( cdtMap(1, ?undef) AS ?map1 )
+	BIND( cdt:Map(1, ?undef) AS ?map1 )
 	BIND( ( ?map1 <= "{1:null}"^^cdt:Map ) AS ?result )
 
 	FILTER( BOUND(?result) )

--- a/tests/map-functions/map-less-than-null-03.rq
+++ b/tests/map-functions/map-less-than-null-03.rq
@@ -2,7 +2,8 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( ( "{1:null}"^^cdt:Map <= "{1:null}"^^cdt:Map ) AS ?result )
+	BIND( cdtMap(1, ?undef) AS ?map1 )
+	BIND( ( ?map1 <= "{1:null}"^^cdt:Map ) AS ?result )
 
 	FILTER( BOUND(?result) )
 	FILTER( ?result = true )

--- a/tests/map-functions/sameterm-01.rq
+++ b/tests/map-functions/sameterm-01.rq
@@ -2,5 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(SAMETERM("{}"^^cdt:Map, "{}"^^cdt:Map))
+	BIND( cdt:Map() AS ?map1 )
+	BIND( cdt:Map() AS ?map2 )
+	FILTER(SAMETERM( ?map1, ?map2))
 }

--- a/tests/map-functions/sameterm-02.rq
+++ b/tests/map-functions/sameterm-02.rq
@@ -2,5 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(SAMETERM("{1: 1}"^^cdt:Map, "{1: 1}"^^cdt:Map))
+	BIND( cdt:Map(1, 1) AS ?map1 )
+	BIND( cdt:Map(1, 1) AS ?map2 )
+	FILTER( SAMETERM(?map1, ?map2) )
 }

--- a/tests/map-functions/sameterm-03.rq
+++ b/tests/map-functions/sameterm-03.rq
@@ -2,6 +2,6 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	BIND( cdt:Map(1, '2'^^<http://www.w3.org/2001/XMLSchema#integer>) AS ?map2 )
-	FILTER(! SAMETERM("{1: 2}"^^cdt:Map, ?map2) )
+	BIND( cdt:Map(1, 2) AS ?map1 )
+	FILTER(! SAMETERM(?map1, "{1: '2'^^<http://www.w3.org/2001/XMLSchema#integer>}"^^cdt:Map) )
 }

--- a/tests/map-functions/sameterm-03.rq
+++ b/tests/map-functions/sameterm-03.rq
@@ -2,5 +2,6 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(! SAMETERM("{1: 2}"^^cdt:Map, "{1: '2'^^<http://www.w3.org/2001/XMLSchema#integer>}"^^cdt:Map))
+	BIND( cdt:Map(1, '2'^^<http://www.w3.org/2001/XMLSchema#integer>) AS ?map2 )
+	FILTER(! SAMETERM("{1: 2}"^^cdt:Map, ?map2) )
 }

--- a/tests/map-functions/sameterm-04.rq
+++ b/tests/map-functions/sameterm-04.rq
@@ -2,5 +2,6 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(! SAMETERM("{ 1: 1 }"^^cdt:Map, "{1:1}"^^cdt:Map))
+	BIND( cdt:Map(1, 1) AS ?map )
+	FILTER(! SAMETERM("{ 1  :  1   }"^^cdt:Map, ?map) )
 }

--- a/tests/map-functions/sameterm-05.rq
+++ b/tests/map-functions/sameterm-05.rq
@@ -2,5 +2,8 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(SAMETERM("{ 1: _:a }"^^cdt:Map, "{ 1: _:a }"^^cdt:Map))
+	BIND( BNODE() AS ?bnode )
+	BIND( cdt:Map(1, ?bnode ) AS ?map1 )
+	BIND( cdt:Map(1, ?bnode ) AS ?map2 )
+	FILTER( SAMETERM( ?map1, ?map2) )
 }

--- a/tests/map-functions/sameterm-null-01.rq
+++ b/tests/map-functions/sameterm-null-01.rq
@@ -2,5 +2,7 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	FILTER(SAMETERM("{1:null}"^^cdt:Map, "{1:null}"^^cdt:Map))
+	BIND( cdt:Map(1, ?undef1) AS ?map1 )
+	BIND( cdt:Map(1, ?undef2) AS ?map2 )
+	FILTER( SAMETERM( ?map1, ?map2 ) )
 }

--- a/tests/orderby/order-map-04.rq
+++ b/tests/orderby/order-map-04.rq
@@ -5,7 +5,7 @@ ASK {
 	{
 		SELECT * WHERE {
 			VALUES (?id ?map) {
-				(1  "{ '01'^^<http://www.w3.org/2001/XMLSchema#integer>: 42 }"^^cdt:Map)
+				(1  "{     '01'^^<http://www.w3.org/2001/XMLSchema#integer>: 42 }"^^cdt:Map)
 				(2  "{ '001'^^<http://www.w3.org/2001/XMLSchema#integer>: 42 }"^^cdt:Map)
 			}
 		}

--- a/tests/orderby/order-map-05.rq
+++ b/tests/orderby/order-map-05.rq
@@ -5,7 +5,7 @@ ASK {
 	{
 		SELECT * WHERE {
 			VALUES (?id ?map) {
-				(1  "{ '1'^^<http://www.w3.org/2001/XMLSchema#string>: 42 }"^^cdt:Map)   # note, different datatype
+				(1  "  { '1'^^<http://www.w3.org/2001/XMLSchema#string>: 42 }"^^cdt:Map)   # note, different datatype
 				(2  "{  '2'^^<http://www.w3.org/2001/XMLSchema#integer>: 42 }"^^cdt:Map)
 			}
 		}

--- a/tests/orderby/order-map-07.rq
+++ b/tests/orderby/order-map-07.rq
@@ -5,7 +5,7 @@ ASK {
 	{
 		SELECT * WHERE {
 			VALUES (?id ?map) {
-				(1  "{ <http://example.org/2> : 42 }"^^cdt:Map)
+				(1  "   { <http://example.org/2> : 42 }"^^cdt:Map)
 				(2  "{  <http://example.org/1> : 42 }"^^cdt:Map)
 			}
 		}

--- a/tests/orderby/order-map-09.rq
+++ b/tests/orderby/order-map-09.rq
@@ -2,14 +2,16 @@ PREFIX cdt:    <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 
 ASK {
-	{
-		SELECT * WHERE {
-			VALUES (?id ?map) {
-				(1  "{ 1: '01'^^<http://www.w3.org/2001/XMLSchema#integer> }"^^cdt:Map)
-				(2  "{ 1: '001'^^<http://www.w3.org/2001/XMLSchema#integer> }"^^cdt:Map)
-			}
-		}
-		ORDER BY ?map LIMIT 1
-	}
-	FILTER ( (?id = 1) || (?id = 2) )
+        {
+                SELECT * WHERE {
+                        VALUES (?id ?map) {
+                                (1  "{ 99: 1 }"^^cdt:Map)
+                                (2  "  { 1: '01'^^<http://www.w3.org/2001/XMLSchema#integer> }"^^cdt:Map)
+                                (3  "  { 1: '001'^^<http://www.w3.org/2001/XMLSchema#integer> }"^^cdt:Map)
+                                (4  "    { 99: 99 }"^^cdt:Map) # a system that doesn't know about CDTs will return this.
+                        }
+                }
+                ORDER BY ?map LIMIT 1
+        }
+        FILTER ( (?id = 2) || (?id = 3) )
 }

--- a/tests/orderby/order-map-11.rq
+++ b/tests/orderby/order-map-11.rq
@@ -5,7 +5,7 @@ ASK {
 	{
 		SELECT * WHERE {
 			VALUES (?id ?map) {
-				(1  "{ 1: <http://example.org/2> }"^^cdt:Map)
+				(1  "   { 1: <http://example.org/2> }"^^cdt:Map)
 				(2  "{ 1: <http://example.org/1> }"^^cdt:Map)
 			}
 		}

--- a/tests/orderby/order-map-14.rq
+++ b/tests/orderby/order-map-14.rq
@@ -6,7 +6,7 @@ ASK {
 		SELECT * WHERE {
 			VALUES (?id ?map) {
 				(1  "{1: 42, 3: 42}"^^cdt:Map)
-				(2  "{2: 42}"^^cdt:Map)
+				(2  "   {2: 42}"^^cdt:Map)
 			}
 		}
 		ORDER BY ?map LIMIT 1

--- a/tests/orderby/order-map-15.rq
+++ b/tests/orderby/order-map-15.rq
@@ -6,7 +6,7 @@ ASK {
 		SELECT * WHERE {
 			VALUES (?id ?map) {
 				(1  "{1: 42, 3: 42}"^^cdt:Map)
-				(2  "{1: 43}"^^cdt:Map)
+				(2  "   {1: 43}"^^cdt:Map)
 			}
 		}
 		ORDER BY ?map LIMIT 1

--- a/tests/orderby/order-map-16.rq
+++ b/tests/orderby/order-map-16.rq
@@ -5,7 +5,7 @@ ASK {
 	{
 		SELECT * WHERE {
 			VALUES (?id ?map) {
-				(1  "{1: 42, 3: 42}"^^cdt:Map)
+				(1  "   {1: 42, 3: 42}"^^cdt:Map)
 				(2  "{1: 42, 2: 42}"^^cdt:Map)
 			}
 		}


### PR DESCRIPTION
*Issue #14 , if available:*

*Description of changes:*

There were some tests succeeding in a system that doesn't handle CDTs. In order to make these tests fail, these got tweaked either by modifying the lexical form of the CDT literals or by using the cdt:List()/cdt:Map() constructors. In the later case, this forces the systems implementing CDT support to implement such constructors. 

